### PR TITLE
Update ItemBuilder to set lore with linebreak "\n"

### DIFF
--- a/src/main/java/com/minecraftlegend/inventoryapi/ItemBuilder.java
+++ b/src/main/java/com/minecraftlegend/inventoryapi/ItemBuilder.java
@@ -77,7 +77,8 @@ public class ItemBuilder {
      */
     public ItemBuilder lore(String str){
         Validate.notNull( str , "Lore is null");
-        meta.getLore().add( str );
+        for(String lore : str.split("\n"))
+            meta.getLore().add( lore );
         item.setItemMeta( meta );
         return this;
     }


### PR DESCRIPTION
The method ItemBuilder.lore("Line1\nLine2") shall add 2 lines instead of just 1.